### PR TITLE
docs: make github PAT info more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ GitHub forks, stars or watchers
 
 This repository is managed by the [Package Maintenance Working Group](https://github.com/nodejs/package-maintenance), see [Governance](https://github.com/nodejs/package-maintenance/blob/master/Governance.md).
 
+### Personal Access Token
+
+Note that to use this tool you need a GitHub personal token set as an
+environment variable named `GITHUB_TOKEN`. For public repositories, no scopes are required. For more information about GitHub
+tokens:
+<https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line>
+
 ### Install
 
 To install this tool run:
@@ -16,7 +23,7 @@ $ npm i -g dependents
 Or via npx:
 
 ```sh
-$ npx dependents [options]
+$ GITHUB_TOKEN=<your token> npx dependents [options]
 ```
 
 ### Require it in your project
@@ -92,7 +99,3 @@ dependents --package express --number 5 --sort downloads --total 25 --json
 ]
 ```
 
-Note that to use this tool you need a GitHub personal token set as an
-environment variable named GITHUB_TOKEN. For more information about GitHub
-tokens:
-<https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->
I went to use the tool and didn't realize until after I had run npx that I needed a github PAT. When creating the PAT I didn't know what scopes I would need.

I updated the docs by moving the PAT info up top into it's own section, added what I believe to be true about not needing any scopes for public repos, and added an env export to the npx example.
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
